### PR TITLE
chore: Do not failfast on PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         jdk: ['8', '11', '17', '21']
 


### PR DESCRIPTION
This lets you see all failures together.
Some failures are related to JDK versions.