### PR TITLE
fix: When repo ends with `.git` infer repo key correctly

### DIFF
--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
@@ -122,10 +122,10 @@ class WaenaPublishedPlugin : Plugin<Project> {
     val origin = scmInfoPlugin.findProvider(project).calculateOrigin(project)
 
     val matchingRegex = listOf(
-      Regex("https://github.com/([^/]+)/([^/]+)"),
-      Regex("git@github.com:([^/]+)/([^/]+)\\.git"),
       Regex("https://github.com/([^/]+)/([^/]+)\\.git"),
-      Regex("git://github.com/([^/]+)/([^/]+)\\.git")
+      Regex("git://github.com/([^/]+)/([^/]+)\\.git"),
+      Regex("git@github.com:([^/]+)/([^/]+)\\.git"),
+      Regex("https://github.com/([^/]+)/([^/]+)"),
     ).find { origin.matches(it) }
     val message = matchingRegex?.matchEntire(origin)
     val repoKey = message?.let { it.groupValues[1] + "/" + it.groupValues[2] } ?: "rahulsom/nothing"


### PR DESCRIPTION
By reordering regexes, `.git` is parsed first.