### PR TITLE
chore: Version control `junit-platform-launcher`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ gradlePublish = "1.3.1"
 jgit = "7.+"
 jreleaser = "1.18.0"
 junit = "5.11.4"
+junitPlatform = "1.13.0"
 nebulaContacts = "7.0.1"
 nebulaPublish = "21.1.0"
 nebulaRelease = "20.2.0"
@@ -19,6 +20,7 @@ jreleaser = { module = "org.jreleaser:org.jreleaser.gradle.plugin", version.ref 
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 nebulaContacts = { module = "com.netflix.nebula:gradle-contacts-plugin", version.ref = "nebulaContacts" }
 nebulaPublish = { module = "com.netflix.nebula:nebula-publishing-plugin", version.ref = "nebulaPublish" }
 nebulaRelease = { module = "com.netflix.nebula:nebula-release-plugin", version.ref = "nebulaRelease" }
@@ -26,7 +28,7 @@ nexusPublish = { module = "io.github.gradle-nexus:publish-plugin", version.ref =
 taskTree = { module = "com.dorongold.plugins:task-tree", version.ref = "taskTree" }
 
 [bundles]
-junit = ["junitApi", "junitJupiter", "junitParams"]
+junit = ["junitApi", "junitJupiter", "junitParams", "junitPlatformLauncher"]
 
 [plugins]
 gradlePublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePublish" }


### PR DESCRIPTION
Without it we run into issues with upgrading junit.
