### PR TITLE
feat: Centralize info plugin application to root project

### DIFF
--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
@@ -23,7 +23,6 @@ class WaenaPublishedPlugin : Plugin<Project> {
     target.plugins.apply(SigningPlugin::class.java)
     target.plugins.apply(ReleasePlugin::class.java)
     target.plugins.apply(NebulaMavenPublishPlugin::class.java)
-    target.plugins.apply(InfoPlugin::class.java)
     target.plugins.withType(JavaBasePlugin::class.java) {
       val javaPluginExtension = target.extensions.getByType(JavaPluginExtension::class.java)
       javaPluginExtension.withJavadocJar()
@@ -118,7 +117,7 @@ class WaenaPublishedPlugin : Plugin<Project> {
   }
 
   private fun getGithubRepoKey(project: Project): String {
-    val scmInfoPlugin = project.plugins.getAt(ScmInfoPlugin::class.java)
+    val scmInfoPlugin = project.rootProject.plugins.getAt(ScmInfoPlugin::class.java)
     val origin = scmInfoPlugin.findProvider(project).calculateOrigin(project)
 
     val matchingRegex = listOf(

--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaRootPlugin.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaRootPlugin.kt
@@ -5,6 +5,7 @@ import com.github.rahulsom.waena.WaenaExtension.PublishMode
 import io.github.gradlenexus.publishplugin.NexusPublishExtension
 import io.github.gradlenexus.publishplugin.NexusPublishPlugin
 import nebula.plugin.contacts.ContactsPlugin
+import nebula.plugin.info.InfoPlugin
 import nebula.plugin.release.ReleasePlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -37,6 +38,7 @@ class WaenaRootPlugin : Plugin<Project> {
     rootProject.plugins.apply(SigningPlugin::class.java)
     rootProject.plugins.apply(ReleasePlugin::class.java)
     rootProject.plugins.apply(TaskTreePlugin::class.java)
+    rootProject.plugins.apply(InfoPlugin::class.java)
     val waenaExtension = rootProject.extensions.create("waena", WaenaExtension::class.java, rootProject)
 
     rootProject.allprojects.forEach { target ->

--- a/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaPublishedPluginTest.kt
+++ b/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaPublishedPluginTest.kt
@@ -24,6 +24,8 @@ class WaenaPublishedPluginTest {
     assertThat(installedPlugins.find { it is SigningPlugin }).isNotNull()
     assertThat(installedPlugins.find { it is ReleasePlugin }).isNotNull()
     assertThat(installedPlugins.find { it is MavenPublishPlugin }).isNotNull()
-    assertThat(installedPlugins.find { it is InfoPlugin }).isNotNull()
+
+    val rootPlugins = rootProject.plugins
+    assertThat(rootPlugins.find { it is InfoPlugin }).isNotNull()
   }
 }


### PR DESCRIPTION
Applied the `info` plugin only to the root project and removed it from the published projects.
This avoids the need to repeatedly apply the plugin.

The `ScmInfoPlugin` is now sourced from the `rootProject` to ensure that it is always available.
