### PR TITLE
feat: add GitHub Packages as a publish target

### DIFF
--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaExtension.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaExtension.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 open class WaenaExtension(project: Project) {
   enum class License(val license: String, val url: String) {
@@ -26,11 +27,24 @@ open class WaenaExtension(project: Project) {
      * Publish to Maven Central via Sonatype Portal
      */
     Central,
+
+    /**
+     * Publish to GitHub Packages
+     */
+    GitHub,
   }
 
   val license: Property<License> = project.objects
     .property(License::class.java)
     .convention(License.Apache2)
+
+  val publishModes: SetProperty<PublishMode> = project.objects
+    .setProperty(PublishMode::class.java)
+
+  @Deprecated(
+    message = "Use publishModes instead",
+    replaceWith = ReplaceWith("publishModes.set(setOf(mode))")
+  )
   val publishMode: Property<PublishMode> = project.objects
     .property(PublishMode::class.java)
     .convention(PublishMode.Central)
@@ -40,8 +54,14 @@ open class WaenaExtension(project: Project) {
     return ObjectMapper().writeValueAsString(
       mapOf<String, Any>(
         "license" to license.get(),
-        "publishMode" to publishMode.get()
+        "publishModes" to resolvedPublishModes()
       )
     )
+  }
+
+  internal fun resolvedPublishModes(): Set<PublishMode> {
+    val explicit = publishModes.getOrElse(emptySet())
+    @Suppress("DEPRECATION")
+    return explicit.ifEmpty { setOf(publishMode.get()) }
   }
 }

--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
@@ -43,6 +43,7 @@ class WaenaPublishedPlugin : Plugin<Project> {
     val publishingExtension = target.extensions.findByType<PublishingExtension>()!!
     val waenaExtension = target.rootProject.extensions.getByType(WaenaExtension::class.java)
     val isSnapshot = target.version.toString().endsWith("SNAPSHOT")
+    val publishModes = waenaExtension.resolvedPublishModes()
 
     publishingExtension.repositories.maven {
       name = "local"
@@ -53,13 +54,27 @@ class WaenaPublishedPlugin : Plugin<Project> {
       url = target.file(repoUrl).toURI()
     }
 
-    if (isSnapshot && waenaExtension.publishMode.get() == WaenaExtension.PublishMode.Central) {
+    if (isSnapshot && WaenaExtension.PublishMode.Central in publishModes) {
       publishingExtension.repositories.maven {
         name = "sonatype"
         url = target.uri(WaenaRootPlugin.CENTRAL.first)
         credentials {
           username = target.rootProject.findProperty("sonatypeUsername") as String? ?: ""
           password = target.rootProject.findProperty("sonatypePassword") as String? ?: ""
+        }
+      }
+    }
+
+    if (WaenaExtension.PublishMode.GitHub in publishModes) {
+      val repoKey = getHostedRepoInfo(target)
+      publishingExtension.repositories.maven {
+        name = "githubPackages"
+        url = target.uri("https://maven.pkg.github.com/${repoKey.repo}")
+        credentials {
+          username = target.rootProject.findProperty("githubPackagesUsername") as String?
+            ?: System.getenv("GITHUB_ACTOR") ?: ""
+          password = target.rootProject.findProperty("githubPackagesPassword") as String?
+            ?: System.getenv("GITHUB_TOKEN") ?: ""
         }
       }
     }

--- a/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaExtensionTest.kt
+++ b/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaExtensionTest.kt
@@ -11,6 +11,7 @@ class WaenaExtensionTest {
     val project = ProjectBuilder.builder().build()
     val extension = WaenaExtension(project)
     assertThat(extension.license.get()).isEqualTo(WaenaExtension.License.Apache2)
+    @Suppress("DEPRECATION")
     assertThat(extension.publishMode.get()).isEqualTo(WaenaExtension.PublishMode.Central)
   }
 
@@ -23,7 +24,19 @@ class WaenaExtensionTest {
   }
 
   @Test
-  fun `can set publish mode`() {
+  fun `can set publish modes`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = WaenaExtension(project)
+    extension.publishModes.set(setOf(WaenaExtension.PublishMode.Central, WaenaExtension.PublishMode.GitHub))
+    assertThat(extension.publishModes.get()).containsExactlyInAnyOrder(
+      WaenaExtension.PublishMode.Central,
+      WaenaExtension.PublishMode.GitHub,
+    )
+  }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun `can set publish mode (deprecated)`() {
     val project = ProjectBuilder.builder().build()
     val extension = WaenaExtension(project)
     extension.publishMode.set(WaenaExtension.PublishMode.Central)
@@ -36,6 +49,6 @@ class WaenaExtensionTest {
     val extension = WaenaExtension(project)
     val extensionConfig = ObjectMapper().readValue(extension.toJson(), Map::class.java)
     assertThat(extensionConfig["license"]).isEqualTo(WaenaExtension.License.Apache2.toString())
-    assertThat(extensionConfig["publishMode"]).isEqualTo(WaenaExtension.PublishMode.Central.toString())
+    assertThat(extensionConfig["publishModes"] as List<*>).containsExactly(WaenaExtension.PublishMode.Central.toString())
   }
 }


### PR DESCRIPTION
## Summary

- Adds `PublishMode.GitHub` to publish artifacts to GitHub Packages
- Replaces the single-valued `publishMode: Property<PublishMode>` with `publishModes: SetProperty<PublishMode>`, so projects can publish to Maven Central, GitHub Packages, or both simultaneously
- Retains the old `publishMode` as a `@Deprecated` backward-compatible fallback that resolves to a singleton set

## Usage

```kotlin
// New API — publish to both
waena {
  publishModes.set(setOf(WaenaExtension.PublishMode.Central, WaenaExtension.PublishMode.GitHub))
}

// Old API still works (deprecated)
waena {
  publishMode.set(WaenaExtension.PublishMode.Central)
}
```

GitHub Packages credentials are read from the `githubPackagesUsername` / `githubPackagesPassword` Gradle properties, falling back to `GITHUB_ACTOR` / `GITHUB_TOKEN` environment variables (standard in GitHub Actions).