### PR TITLE
fix: skip GitHub Packages repository for snapshot builds

### DIFF
--- a/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
+++ b/waena-plugin/src/main/kotlin/com/github/rahulsom/waena/WaenaPublishedPlugin.kt
@@ -65,7 +65,7 @@ class WaenaPublishedPlugin : Plugin<Project> {
       }
     }
 
-    if (WaenaExtension.PublishMode.GitHub in publishModes) {
+    if (!isSnapshot && WaenaExtension.PublishMode.GitHub in publishModes) {
       val repoKey = getHostedRepoInfo(target)
       publishingExtension.repositories.maven {
         name = "githubPackages"


### PR DESCRIPTION
## Summary

- GitHub Packages repository was being registered for all builds, causing snapshot publishes to fail with HTTP 403 (the snapshot `GITHUB_TOKEN` only has `Packages: read`)
- Mirrors the existing pattern: `sonatype` is registered only for snapshots; `githubPackages` is now registered only for non-snapshots (candidates and finals)