### PR TITLE
perf(ci): cache Gradle wrapper distributions used by functional tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,13 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
 
+      - name: Cache Gradle wrapper distributions
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: gradle-wrapper-dists-${{ hashFiles('waena-plugin/src/test/kotlin/**/*.kt') }}
+          restore-keys: gradle-wrapper-dists-
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 


### PR DESCRIPTION
## Summary

- The functional tests download Gradle 9.1.0, 9.2.1, and 9.4.0 via `GradleRunner.withGradleVersion()`. `gradle/actions/setup-gradle` only caches the project wrapper's own distribution, so these test versions are re-downloaded on every CI run.
- The first test for each new Gradle version (especially 9.1.0 at ~3.5 min) spends most of its time waiting for the download. Caching `~/.gradle/wrapper/dists` eliminates that cost on warm runs.
- Cache key is keyed on the test source files so it invalidates when the version list in `testParameters()` changes.