### PR TITLE
perf(test): increase parallel test forks and remove redundant Gradle version

### DIFF
--- a/waena-plugin/build.gradle.kts
+++ b/waena-plugin/build.gradle.kts
@@ -82,6 +82,7 @@ tasks.named("publishPlugins").configure {
 
 tasks.withType<Test> {
   useJUnitPlatform()
+  maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 }
 
 testlogger {

--- a/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaPluginFunctionalTest.kt
+++ b/waena-plugin/src/test/kotlin/com/github/rahulsom/waena/WaenaPluginFunctionalTest.kt
@@ -53,7 +53,7 @@ class WaenaPluginFunctionalTest {
 
     @JvmStatic
     fun testParameters(): Stream<Arguments> {
-      val gradleVersion = listOf(null, "9.1.0", "9.2.1", "9.4.0")
+      val gradleVersion = listOf(null, "9.1.0", "9.4.0")
       val publishModes = listOf(null, "Central")
       val taskTasksPairs = listOf(
         Pair(SNAPSHOT, SNAPSHOT_TASKS),


### PR DESCRIPTION
## Summary

- Sets `maxParallelForks` to half the available CPUs so the JUnit runner fully utilises the GitHub Actions runner's 4 cores across functional tests. Without an explicit setting the default is 1.
- Removes `9.2.1` from the Gradle version matrix in `testParameters()`. It sits between `9.1.0` and `9.4.0` and doesn't cover any additional API boundary. Each removed version eliminates 6 test cases (~12 Gradle builds).